### PR TITLE
Add Event ABI to test signature

### DIFF
--- a/func_sig_registry/utils/abi.py
+++ b/func_sig_registry/utils/abi.py
@@ -44,6 +44,16 @@ INPUTS = OUTPUTS = {'type': 'array', 'items': {'$ref': '#/definitions/argument'}
 EVENT_TYPE = {'type': 'string', 'enum': ['event']}
 CONSTRUCTOR_TYPE = {'type': 'string', 'enum': ['constructor']}
 
+EVENT_ARGUMENT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': NAME,
+        'type': NAME,
+        'indexed' : BOOLEAN,
+    },
+    'required': ['name', 'type', 'indexed'],
+}
+
 FUNCTION_SCHEMA = {
     'type': 'object',
     'properties': {
@@ -64,13 +74,13 @@ EVENT_SCHEMA = {
     'properties': {
         'anonymous': BOOLEAN,
         'type': {'type': 'string', 'enum': ['event']},
-        'inputs': INPUTS,
+        'inputs': {
+            'type': 'array', 
+            'items': EVENT_ARGUMENT_SCHEMA,
+        },
         'name': NAME,
     },
     'required': ['type', 'inputs', 'name'],
-    'definitions': {
-        'argument': ARGUMENT_SCHEMA,
-    },
 }
 
 CONSTRUCTOR_SCHEMA = {
@@ -120,6 +130,15 @@ def function_definition_to_text_signature(abi: Dict[str, Any]) -> str:
         ),
     )
 
-#TODO
+
 def event_definition_to_text_signature(abi: Dict[str, Any]) -> str:
-    pass
+    for abi_input in abi.get('inputs', []):
+        print(abi_input)
+
+    return '{fn_name}({fn_input_types})'.format(
+        fn_name=abi['name'],
+        fn_input_types=','.join(
+            [f"{collapse_if_tuple(abi_input)}{' indexed' if abi_input['indexed'] else ''}" 
+            for abi_input in abi.get('inputs', [])]
+        ),
+    )

--- a/tests/web/utility/test_event_definition_to_text_signature.py
+++ b/tests/web/utility/test_event_definition_to_text_signature.py
@@ -1,0 +1,46 @@
+import json
+
+import pytest
+
+from func_sig_registry.utils.abi import (
+    event_definition_to_text_signature,
+)
+
+
+ABI_SINGLE_ARG = {
+    "inputs": [
+        {"name": "a", "type": "int256", "indexed" : False},
+    ],
+    "name": "foo",
+    "type": "event",
+    "anonymous": False,
+}
+
+
+ABI_TWO_ARGS = {
+    "inputs": [
+        {"name": "a", "type": "address", "indexed" : True},
+        {"name": "b", "type": "uint256", "indexed" : False},
+    ],
+    "name": "foo",
+    "type": "event",
+    "anonymous": False,
+}
+
+ABI_TUPLE_ARG = json.loads('{"inputs":[{"indexed":false, "components":[{"internalType":"int256","name":"x","type":"int256"},{"internalType":"int256","name":"y","type":"int256"}],"internalType":"struct Test2.Test","name":"a","type":"tuple"}],"name":"myEvent","type":"event"}')
+
+ABI_GET_ORDERS_INFO = json.loads('{"inputs":[{"indexed":false, "components":[{"name":"makerAddress","type":"address"},{"name":"takerAddress","type":"address"},{"name":"feeRecipientAddress","type":"address"},{"name":"senderAddress","type":"address"},{"name":"makerAssetAmount","type":"uint256"},{"name":"takerAssetAmount","type":"uint256"},{"name":"makerFee","type":"uint256"},{"name":"takerFee","type":"uint256"},{"name":"expirationTimeSeconds","type":"uint256"},{"name":"salt","type":"uint256"},{"name":"makerAssetData","type":"bytes"},{"name":"takerAssetData","type":"bytes"}],"name":"orders","type":"tuple[]"}],"name":"OrdersInfo","type":"event"}')
+
+
+@pytest.mark.parametrize(
+    'fn_abi,expected',
+    (
+        (ABI_SINGLE_ARG, 'foo(int256)'),
+        (ABI_TWO_ARGS, 'foo(address indexed,uint256)'),
+        (ABI_TUPLE_ARG, 'myEvent((int256,int256))'),
+        (ABI_GET_ORDERS_INFO, 'OrdersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[])'),
+    ),
+)
+def test_function_definition_to_text_signature(fn_abi, expected):
+    actual = event_definition_to_text_signature(fn_abi)
+    assert actual == expected

--- a/tests/web/utility/test_is_valid_contract_abi.py
+++ b/tests/web/utility/test_is_valid_contract_abi.py
@@ -18,6 +18,35 @@ SOME_OF_EACH = json.loads('[{"constant":false,"inputs":[],"name":"f","outputs":[
 
 SOME_OF_EACH_AND_THREE_FUNCTIONS = json.loads('[{"constant":false,"inputs":[{"name":"","type":"uint256"},{"name":"","type":"int256"},{"name":"","type":"address"}],"name":"c","outputs":[],"type":"function"},{"constant":false,"inputs":[],"name":"f","outputs":[],"type":"function"},{"constant":false,"inputs":[{"name":"","type":"int256"},{"name":"","type":"int256"}],"name":"b","outputs":[],"type":"function"},{"inputs":[],"type":"constructor"},{"anonymous":false,"inputs":[],"name":"E","type":"event"}]')
 
+SINGLE_EVENT_INDEXED = [{
+    "type":"event",
+    "inputs": [
+        {"name":"a","type":"uint256","indexed":True},
+        {"name":"b","type":"bytes32","indexed":False}
+        ],
+    "name":"foo",
+    "anonymous" : False
+}]
+
+MISSING_INDEXED_EVENT = [{
+    "type":"event",
+    "inputs": [
+        {"name":"a","type":"uint256"},
+        {"name":"b","type":"bytes32","indexed":False}
+        ],
+    "name":"foo",
+    "anonymous" : False
+}]
+
+INCORRECT_INDEXED_TYPE = [{
+    "type":"event",
+    "inputs": [
+        {"name":"a","type":"uint256","indexed":"True"},
+        {"name":"b","type":"bytes32","indexed":False}
+        ],
+    "name":"foo",
+    "anonymous" : False
+}]
 
 MISSING_FUNCTION_NAME = [{
     'constant': True,
@@ -38,6 +67,7 @@ ABI_TUPLE_ARG = json.loads('[{"constant":false,"inputs":[{"components":[{"intern
 # from 0x4f833a24e1f95d70f028921e27040ca56e09ab0b mainnet address:
 # https://github.com/pipermerriam/ethereum-function-signature-registry/issues/37
 ABI_GET_ORDERS_INFO = json.loads('[{"constant":true,"inputs":[{"components":[{"name":"makerAddress","type":"address"},{"name":"takerAddress","type":"address"},{"name":"feeRecipientAddress","type":"address"},{"name":"senderAddress","type":"address"},{"name":"makerAssetAmount","type":"uint256"},{"name":"takerAssetAmount","type":"uint256"},{"name":"makerFee","type":"uint256"},{"name":"takerFee","type":"uint256"},{"name":"expirationTimeSeconds","type":"uint256"},{"name":"salt","type":"uint256"},{"name":"makerAssetData","type":"bytes"},{"name":"takerAssetData","type":"bytes"}],"name":"orders","type":"tuple[]"}],"name":"getOrdersInfo","outputs":[{"components":[{"name":"orderStatus","type":"uint8"},{"name":"orderHash","type":"bytes32"},{"name":"orderTakerAssetFilledAmount","type":"uint256"}],"name":"","type":"tuple[]"}],"payable":false,"stateMutability":"view","type":"function"}]')
+
 
 
 @pytest.mark.parametrize(
@@ -63,6 +93,11 @@ ABI_GET_ORDERS_INFO = json.loads('[{"constant":true,"inputs":[{"components":[{"n
         # bad definitions
         (MISSING_FUNCTION_NAME, False),
         (MISSING_FUNCTION_TYPE, False),
+        (MISSING_INDEXED_EVENT, False),
+        (INCORRECT_INDEXED_TYPE, False),
+        # event with indexed
+        (SINGLE_EVENT_INDEXED, True),
+
     ),
 )
 def test_is_valid_contract_abi(contract_abi, expected):


### PR DESCRIPTION
### What was wrong?
- ABI Validator and Parser was not implemented

### How was it fixed?

- Modify `is_valid_contract_abi()` and `event_definition_to_text_signature()`
- Write tests